### PR TITLE
Fix escaped quote string syntax highlighting

### DIFF
--- a/grammars/hoon.cson
+++ b/grammars/hoon.cson
@@ -38,12 +38,14 @@ patterns: [
     begin: "\\\""
     comment: "tape"
     end: "\\\""
+    patterns: [{include: '#escaped_char'}]
     name: "string.double.hoon"
   }
   {
     begin: "\\'"
     comment: "cord"
     end: "\\'"
+    patterns: [{include: '#escaped_char'}]
     name: "string.single.hoon"
   }
   {
@@ -79,3 +81,6 @@ patterns: [
   }
 ]
 scopeName: "source.hoon"
+repository:
+  escaped_char:
+    match: '\\\\.'


### PR DESCRIPTION
tl;dr: Fixes this:

![language-hoon](https://cloud.githubusercontent.com/assets/13459143/25871970/f836305c-34bd-11e7-8122-e10116f5f9f9.png)

Fixes an issue where escaped single or double quotes aren't parsed correctly and
correctly-closed Hoon string quotes continue to "stringify" the rest of
a .hoon file in Atom until the next closing respective single or double quote.


Also, @yonilevy, since a number of Urbit programmers are using this
package, would it be cool if you let us maintain this repo and APM
management in an official github/urbit repo? We think it'd be helpful to the community
to have it beside our Vim, Emacs, and Sublime editor tools for Hoon (which also
all need serious improvement), and having everything in one place is a good place
to start encouraging contribution. Also, it helps the Urbit community to have our 
official logo on APM when you search for the package in Atom.

Feel free to reach out to me directly via email or Twitter if this is
something you're cool with! We'll still credit you of course. :)
(Serious thank-you for creating this in the first place!)
